### PR TITLE
Remove not necessary dotnet CLI arguments for publishing

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
+  <PropertyGroup>
+    <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,5 +2,8 @@
   <!-- See https://aka.ms/dotnet/msbuild/customize for more details on customizing your build -->
   <PropertyGroup>
     <ArtifactsPath>$(MSBuildThisFileDirectory)artifacts</ArtifactsPath>
+    <!-- Workaround for bug in SDK - https://github.com/dotnet/sdk/issues/12114 -->
+    <IntermediateOutputPath>$(ArtifactsPath)/obj/$(MSBuildProjectName)/$(Configuration)/</IntermediateOutputPath>
+    <OutputPath>$(ArtifactsPath)/bin/$(MSBuildProjectName)/$(Configuration)/</OutputPath>
   </PropertyGroup>
 </Project>

--- a/GenerateSelfSignedCertificate/GenerateSelfSignedCertificate.csproj
+++ b/GenerateSelfSignedCertificate/GenerateSelfSignedCertificate.csproj
@@ -7,6 +7,7 @@
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <LangVersion>latest</LangVersion>
         <SelfContained>false</SelfContained>
+        <_UpdateAppHostForPublish>true</_UpdateAppHostForPublish>
     </PropertyGroup>
 
     <ItemGroup>

--- a/GenerateSelfSignedCertificate/GenerateSelfSignedCertificate.csproj
+++ b/GenerateSelfSignedCertificate/GenerateSelfSignedCertificate.csproj
@@ -1,18 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <Platform>x64</Platform>
-        <Platforms>$(Platform)</Platforms>
-        <PlatformTarget>$(Platform)</PlatformTarget>
-        <OutputPath>$(Platform)\$(Configuration)</OutputPath>
-
         <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
-
-        <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
-        <AppendRuntimeIdentifierToOutputPath>true</AppendRuntimeIdentifierToOutputPath>
-
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <LangVersion>latest</LangVersion>
         <SelfContained>false</SelfContained>
@@ -22,4 +13,5 @@
         <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0" />
     </ItemGroup>
 
+  <Import Project="../PublishAllRids.targets" />
 </Project>

--- a/PublishAllRids.targets
+++ b/PublishAllRids.targets
@@ -17,10 +17,6 @@
       <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
         <AdditionalProperties>
           RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity)
-          ;NoBuild=true
-          ;OutputPath=$(OutputPath)
-          ;IntermediateOutputPath=$(IntermediateOutputPath)
-          ;_UpdateAppHostForPublish=true
         </AdditionalProperties>
       </ProjectToPublish>
     </ItemGroup>

--- a/PublishAllRids.targets
+++ b/PublishAllRids.targets
@@ -1,0 +1,34 @@
+<Project DefaultTargets="Build">
+
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <!-- Enable roll-forward to latest patch.  This allows one restore operation
+         to apply to all of the self-contained publish operations. -->
+    <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+  </PropertyGroup>
+
+  <Target Name="PublishAllRids">
+    <ItemGroup>
+      <!-- Transform RuntimeIdentifiers property to item -->
+      <RuntimeIdentifierForPublish Include="$(RuntimeIdentifiers)" />
+
+      <!-- Transform RuntimeIdentifierForPublish items to project items to pass to MSBuild task -->
+      <ProjectToPublish Include="@(RuntimeIdentifierForPublish->'$(MSBuildProjectFullPath)')">
+        <AdditionalProperties>
+          RuntimeIdentifier=%(RuntimeIdentifierForPublish.Identity)
+          ;NoBuild=true
+          ;OutputPath=$(OutputPath)
+          ;IntermediateOutputPath=$(IntermediateOutputPath)
+          ;_UpdateAppHostForPublish=true
+        </AdditionalProperties>
+      </ProjectToPublish>
+    </ItemGroup>
+
+    <MSBuild Projects="@(ProjectToPublish)"
+             Targets="Publish"
+             BuildInParallel="true"
+             />
+  </Target>
+
+</Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+      "version": "9.0.100",
+      "rollForward": "latestFeature"
+    }
+}


### PR DESCRIPTION
Full list of changes:

1. Used ArtifactsOutput to manage paths. This makes it easier to clean up all artifacts generated by dotnet CLI commands.
2. Replaced command for calling "_CreateAppHost" with MSBuild flag "_UpdateAppHostForPublish=true" (build-in MSBuild flag that force _CreateAppHost during publish)
3. Added a custom target to execute publishing to all runtime identifiers in parallel